### PR TITLE
Add missing header

### DIFF
--- a/include/gepetto/viewer/OSGManipulator/keyboard-manipulator.h
+++ b/include/gepetto/viewer/OSGManipulator/keyboard-manipulator.h
@@ -91,7 +91,7 @@ namespace osgGA {
     key_roll_right = GUIEventAdapter::KEY_E,
     key_roll_left = GUIEventAdapter::KEY_Q,
     key_up = GUIEventAdapter::KEY_Space,
-    key_down = GUIEventAdapter::KEY_C
+    key_down = GUIEventAdapter::KEY_V
   };
 
   enum keyLayout{

--- a/src/OSGManipulator/keyboard-manipulator.cpp
+++ b/src/OSGManipulator/keyboard-manipulator.cpp
@@ -9,6 +9,7 @@
 //
 #include <stdlib.h>
 #include <stdio.h>
+#include <iostream>
 #include <gepetto/viewer/OSGManipulator/keyboard-manipulator.h>
 #include <gepetto/viewer/config-osg.h>
 


### PR DESCRIPTION
`iostream` header is missing when compiling on my laptop.

Use V to go up instead of C because C is already used for screen capture.
